### PR TITLE
added creditnotec to attach iva condiction

### DIFF
--- a/pkg/afip/wsfe/service.go
+++ b/pkg/afip/wsfe/service.go
@@ -156,7 +156,7 @@ func (s *Service) CaeRequest(cabRequest *CabRequest, caeRequest *CaeRequest) (st
 		FchServHasta:           "",
 	}
 
-	if cabRequest.CbteTipo != FacturaC &&
+	if cabRequest.CbteTipo != FacturaC && cabRequest.CbteTipo != NotaCreditoC &&
 		(caeRequest.ImpIVA > 0 || caeRequest.ImpNeto > 0) {
 		feDetRequest.Iva = &arrayOfAlicIvas
 	}


### PR DESCRIPTION
The condition for attaching VAT has been corrected by adding the Credit Note C condition. This avoids the AFIP message "Para comprobantes tipo C el objeto IVA no debe informarse."